### PR TITLE
refactoring: DB query api of Candidate table

### DIFF
--- a/backend/DB/queries/candidate.js
+++ b/backend/DB/queries/candidate.js
@@ -2,15 +2,43 @@ import Sequelize from "sequelize";
 import models from "../models";
 
 const Op = Sequelize.Op;
+const Candidate = models.Candidate;
 
 // eslint-disable-next-line import/prefer-default-export
 export async function getCandidatesByPollId(pollIdList) {
 	// noinspection JSUnresolvedVariable
-	return models.Candidate.findAll({
+	const result = models.Candidate.findAll({
 		where: {
 			PollId: {
 				[Op.or]: pollIdList,
 			},
 		},
 	});
+
+	return result.map(x => x.get({plain: true}));
+}
+
+/**
+ *
+ * @param content {String}
+ * @param number {Number}
+ * @param PollId {Number|null}
+ * @return {Promise<Object>} created Candidate object
+ */
+export async function createCandidate({content, number, PollId}) {
+	const result = await Candidate.create({content, number, PollId});
+
+	return result.get({plain: true});
+}
+
+/**
+ *
+ * @param candidates {Object[]}
+ * @param transaction
+ * @return {Promise<Object[]>} bulk created Candidate objects
+ */
+export async function createBulkCandidates(candidates, transaction) {
+	const result = await Candidate.bulkCreate(candidates, {transaction});
+
+	return result.map(x => x.get({plain: true}));
 }

--- a/backend/DB/queries/poll.js
+++ b/backend/DB/queries/poll.js
@@ -1,5 +1,6 @@
 import models from "../models";
 import logger from "../logger.js";
+import {createBulkCandidates} from "./candidate.js";
 
 const sequelize = models.sequelize;
 // noinspection JSUnresolvedVariable
@@ -102,7 +103,7 @@ export async function createPoll(
 		// step 2
 		const rows = makeCandidateRows(poll.id, pollType, candidates);
 
-		nItems = await Candidate.bulkCreate(rows, {transaction});
+		nItems = createBulkCandidates(rows, transaction);
 
 		// commit
 		await transaction.commit();
@@ -114,7 +115,7 @@ export async function createPoll(
 
 	if (poll && nItems) {
 		poll = poll.get({plain: true});
-		poll.nItems = nItems.map(item => item.get({plain: true}));
+		poll.nItems = nItems;
 	}
 
 	return poll;

--- a/backend/graphQL/model/poll/resolveHelper.js
+++ b/backend/graphQL/model/poll/resolveHelper.js
@@ -10,6 +10,7 @@ export const simplifyList = list => list.map(n => n.get({plain: true}));
  * CandidateId (int) 만 읽어서 array로 반환해주는 함수
  */
 export const getCandidateList = items => items.map(n => n.id);
+
 /**
  *
  * @param {int} pollId
@@ -63,9 +64,8 @@ export async function getItems(pollId, candidates) {
  */
 export async function getCandidatesByPolls(polls) {
 	const pollIdList = polls.map(poll => poll.id);
-	const candidates = await getCandidatesByPollId(pollIdList);
 
-	return simplifyList(candidates);
+	return getCandidatesByPollId(pollIdList);
 }
 
 /**

--- a/backend/spec/DB/queries/CandidateQuery.test.js
+++ b/backend/spec/DB/queries/CandidateQuery.test.js
@@ -1,0 +1,76 @@
+import assert from "assert";
+import {before, beforeEach, describe, it} from "mocha";
+import models from "../../../DB/models";
+import {
+	createBulkCandidates,
+	createCandidate,
+	getCandidatesByPollId,
+} from "../../../DB/queries/candidate.js";
+
+describe("candidate DB query api", () => {
+	before(async () => {
+		await models.sequelize.sync();
+	});
+
+	beforeEach(async () => {
+		await models.Candidate.destroy({where: {}, truncate: true});
+	});
+
+	it("should be able to create candidate", async () => {
+		// given
+		const number = 1;
+		const content = "content";
+		const PollId = null;
+
+		// when
+		const candidate = await createCandidate({content, PollId, number});
+
+		// than
+		assert(candidate.id > 0);
+		assert.equal(candidate.number, number);
+		assert.equal(candidate.PollId, PollId);
+		assert.equal(candidate.content, content);
+	});
+
+	it("should able to getCandidatesByPollId", async () => {
+		// given
+		const number = 1;
+		const content = "content";
+		const PollId = null;
+		const candidate = await createCandidate({content, PollId, number});
+
+		// when
+		const result = await getCandidatesByPollId([PollId]);
+
+		const expected = [candidate];
+
+		// than
+		assert.deepStrictEqual(result, expected);
+	});
+
+	it("should able to createBulkCandidates", async () => {
+		const candidates = [
+			{
+				number: 1,
+				content: "content1",
+				PollId: null,
+			},
+			{
+				number: 2,
+				content: "content2",
+				PollId: null,
+			},
+		];
+
+		const result = await createBulkCandidates(candidates);
+
+		assert(result.length === 2);
+		assert.equal(result[0].number, 1);
+		assert.equal(result[0].content, "content1");
+		assert.equal(result[0].PollId, null);
+
+		assert.equal(result[1].content, "content2");
+		assert.equal(result[1].number, 2);
+		assert.equal(result[1].PollId, null);
+	});
+});


### PR DESCRIPTION
* getCandidatesByPollId의 반환 타입을 js plain object 형태로 변경
* createCandidate 함수 추가
* createBulkCandidates 함수 추가
* createPoll 함수의 내부의 Candidate.bulkCreate 부분을 createBulkCandidates 로 수정
* 테스트 추가
