### PR TITLE
refactoring: change minor in Poll DB Query api

### DIFF
--- a/backend/DB/queries/poll.js
+++ b/backend/DB/queries/poll.js
@@ -8,6 +8,9 @@ const Poll = models.Poll;
 
 export const POLL_STATE_RUNNING = "running";
 export const POLL_STATE_CLOSED = "closed";
+export const POLL_STATE_STAND_BY = "standby";
+
+export const POLL_TYPE_N_ITEMS = "nItems";
 
 /**
  *
@@ -62,6 +65,46 @@ export async function getPollsByEventId(EventId) {
 	return res.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param EventId {Number|null}
+ * @param pollName {String}
+ * @param pollType {String}
+ * @param selectionType {String}
+ * @param allowDuplication {Boolean}
+ * @param state {String}
+ * @param pollDate {Date}
+ * @param transaction
+ * @return {Promise<Object>} created poll object
+ */
+export async function createPoll(
+	{
+		EventId,
+		pollName,
+		pollType,
+		selectionType,
+		allowDuplication,
+		state = POLL_STATE_STAND_BY,
+		pollDate = new Date(),
+	},
+	transaction = undefined,
+) {
+	const result = await Poll.create(
+		{
+			EventId,
+			pollName,
+			pollType,
+			selectionType,
+			allowDuplication,
+			state,
+			pollDate,
+		},
+		{transaction},
+	);
+
+	return result.get({plain: true});
+}
+
 // todo: refactoring
 const makeCandidateRows = (id, pollType, candidates) => {
 	let i = 0;
@@ -71,7 +114,8 @@ const makeCandidateRows = (id, pollType, candidates) => {
 		nItems.push({
 			PollId: id,
 			number: i,
-			content: pollType === "nItems" ? value : (i + 1).toString(),
+			content:
+				pollType === POLL_TYPE_N_ITEMS ? value : (i + 1).toString(),
 		});
 		i++;
 	}
@@ -82,15 +126,13 @@ const makeCandidateRows = (id, pollType, candidates) => {
 // todo: refactoring
 // look for inject transaction object
 // https://sequelize.org/master/manual/transactions.html#automatically-pass-transactions-to-all-queries
-export async function createPoll(
+export async function createPollAndCandidates(
 	EventId,
 	pollName,
 	pollType,
 	selectionType,
 	allowDuplication,
 	candidates,
-	state = "standby",
-	pollDate = new Date(),
 ) {
 	let transaction;
 	let poll;
@@ -101,36 +143,30 @@ export async function createPoll(
 		transaction = await sequelize.transaction();
 
 		// step 1
-		poll = await Poll.create(
-			{
-				EventId,
-				pollName,
-				pollType,
-				selectionType,
-				allowDuplication,
-				state,
-				pollDate,
-			},
-			{transaction},
+		poll = await createPoll(
+			{EventId, pollName, pollType, selectionType, allowDuplication},
+			transaction,
 		);
 
 		// step 2
-		const rows = makeCandidateRows(poll.id, pollType, candidates);
+		const candidateRows = makeCandidateRows(poll.id, pollType, candidates);
 
-		nItems = createBulkCandidates(rows, transaction);
+		nItems = createBulkCandidates(candidateRows, transaction);
 
 		// commit
 		await transaction.commit();
+
+		poll.nItems = nItems;
+
+		return poll;
 	} catch (err) {
 		// Rollback transaction only if the transaction object is defined
-		if (transaction) await transaction.rollback();
+		if (transaction) {
+			await transaction.rollback();
+		}
+
 		logger.error("Transaction rollback", err);
-	}
 
-	if (poll && nItems) {
-		poll = poll.get({plain: true});
-		poll.nItems = nItems;
+		return null;
 	}
-
-	return poll;
 }

--- a/backend/DB/queries/poll.js
+++ b/backend/DB/queries/poll.js
@@ -5,32 +5,47 @@ import {createBulkCandidates} from "./candidate.js";
 const sequelize = models.sequelize;
 // noinspection JSUnresolvedVariable
 const Poll = models.Poll;
-// noinspection JSUnresolvedVariable
-const Candidate = models.Candidate;
 
+export const POLL_STATE_RUNNING = "running";
+export const POLL_STATE_CLOSED = "closed";
+
+/**
+ *
+ * @param id {Number|null} poll id
+ * @return {Promise<number>} affected row number
+ */
 export async function openPoll(id) {
 	// result should be == [1], 1개의 row가 성공했다는 의미
-	return Poll.update(
+	const result = await Poll.update(
 		{
-			state: "running",
+			state: POLL_STATE_RUNNING,
 			pollDate: new Date(),
 		},
 		{
 			where: {id},
 		},
 	);
+
+	return result[0];
 }
 
+/**
+ *
+ * @param id {Number|null} poll id
+ * @return {Promise<number>} affected row number
+ */
 export async function closePoll(id) {
 	// result should be == [1], 1개의 row가 성공했다는 의미
-	return Poll.update(
+	const result = await Poll.update(
 		{
-			state: "closed",
+			state: POLL_STATE_CLOSED,
 		},
 		{
 			where: {id},
 		},
 	);
+
+	return result[0];
 }
 
 /**
@@ -74,13 +89,12 @@ export async function createPoll(
 	selectionType,
 	allowDuplication,
 	candidates,
+	state = "standby",
+	pollDate = new Date(),
 ) {
 	let transaction;
 	let poll;
 	let nItems;
-
-	const state = "standby";
-	const pollDate = new Date();
 
 	try {
 		// get transaction

--- a/backend/socket_io_server/socketHandler/Poll/closePoll.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Poll/closePoll.socketHandler.js
@@ -6,17 +6,20 @@ const closePollSocketHandler = async (data, emit) => {
 		let status = "ok";
 		const {pollId} = data;
 
-		const result = await closePoll(pollId);
+		const affectedRows = await closePoll(pollId);
 
-		if (result[0] !== 1) {
+		if (affectedRows !== 1) {
 			logger.error(
-				`Something wrong with poll/close: affected number of rows = ${result[0]}`,
+				`Something wrong with poll/close: affected number of rows = ${affectedRows}`,
 			);
+
 			status = "error";
 		}
+
 		emit({status, pollId});
 	} catch (e) {
 		logger.error(e);
+
 		emit({status: "error", e});
 	}
 };

--- a/backend/socket_io_server/socketHandler/Poll/createPoll.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Poll/createPoll.socketHandler.js
@@ -1,4 +1,4 @@
-import {createPoll} from "../../../DB/queries/poll";
+import {createPollAndCandidates} from "../../../DB/queries/poll";
 import logger from "../../logger.js";
 
 const createPollSocketHandler = async (data, emit) => {
@@ -12,7 +12,7 @@ const createPollSocketHandler = async (data, emit) => {
 			candidates,
 		} = data;
 
-		const poll = await createPoll(
+		const poll = await createPollAndCandidates(
 			EventId,
 			pollName,
 			pollType,

--- a/backend/socket_io_server/socketHandler/Poll/openPoll.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Poll/openPoll.socketHandler.js
@@ -5,18 +5,20 @@ const openPollSocketHandler = async (data, emit) => {
 	try {
 		let status = "ok";
 		const {pollId} = data;
+		const affectedRows = await openPoll(pollId);
 
-		const result = await openPoll(pollId);
-
-		if (result[0] !== 1) {
+		if (affectedRows !== 1) {
 			logger.error(
-				`Something wrong with poll/open: affected number of rows = ${result[0]}`,
+				`Something wrong with poll/open: affected number of rows = ${affectedRows}`,
 			);
+
 			status = "error";
 		}
+
 		emit({status, pollId});
 	} catch (e) {
 		logger.error(e);
+
 		emit({status: "error", e});
 	}
 };

--- a/backend/spec/DB/queries/pollQuery.test.js
+++ b/backend/spec/DB/queries/pollQuery.test.js
@@ -1,7 +1,13 @@
 import assert from "assert";
 import {before, beforeEach, describe, it} from "mocha";
 import models from "../../../DB/models";
-import {getPollsByEventId} from "../../../DB/queries/poll.js";
+import {
+	closePoll,
+	getPollsByEventId,
+	openPoll,
+	POLL_STATE_CLOSED,
+	POLL_STATE_RUNNING,
+} from "../../../DB/queries/poll.js";
 
 describe("poll query api", () => {
 	const Poll = models.Poll;
@@ -43,5 +49,63 @@ describe("poll query api", () => {
 		// than
 		assert(res.length > 0);
 		assert.deepStrictEqual(res[0], poll);
+	});
+
+	it("should able to openPoll", async () => {
+		const EventId = null;
+		const pollName = "poll name";
+		const pollType = "nItem";
+		const selectionType = "sim";
+		const allowDuplication = false;
+		const state = "standby";
+		const pollDate = new Date();
+
+		const poll = await Poll.create({
+			EventId,
+			pollName,
+			pollType,
+			selectionType,
+			allowDuplication,
+			state,
+			pollDate,
+		});
+
+		// when
+		const result = await openPoll(poll.id);
+
+		// than
+		assert.equal(result, 1);
+		const real = await Poll.findOne({where: {id: poll.id}});
+
+		assert.equal(real.state, POLL_STATE_RUNNING);
+	});
+
+	it("should able to closePoll", async () => {
+		const EventId = null;
+		const pollName = "poll name";
+		const pollType = "nItem";
+		const selectionType = "sim";
+		const allowDuplication = false;
+		const state = "standby";
+		const pollDate = new Date();
+
+		const poll = await Poll.create({
+			EventId,
+			pollName,
+			pollType,
+			selectionType,
+			allowDuplication,
+			state,
+			pollDate,
+		});
+
+		// when
+		const result = await closePoll(poll.id);
+
+		// than
+		assert.equal(result, 1);
+		const real = await Poll.findOne({where: {id: poll.id}});
+
+		assert.equal(real.state, POLL_STATE_CLOSED);
 	});
 });

--- a/backend/spec/DB/queries/pollQuery.test.js
+++ b/backend/spec/DB/queries/pollQuery.test.js
@@ -3,6 +3,7 @@ import {before, beforeEach, describe, it} from "mocha";
 import models from "../../../DB/models";
 import {
 	closePoll,
+	createPoll,
 	getPollsByEventId,
 	openPoll,
 	POLL_STATE_CLOSED,
@@ -20,7 +21,7 @@ describe("poll query api", () => {
 		await models.Poll.destroy({where: {}, truncate: true});
 	});
 
-	it("should able to create Like", async () => {
+	it("should able to getPollsByEventId", async () => {
 		// given
 
 		const EventId = null;
@@ -107,5 +108,31 @@ describe("poll query api", () => {
 		const real = await Poll.findOne({where: {id: poll.id}});
 
 		assert.equal(real.state, POLL_STATE_CLOSED);
+	});
+
+	it("should able to create poll", async () => {
+		// given
+		const EventId = null;
+		const pollName = "poll name";
+		const pollType = "poll type";
+		const selectionType = "selection type";
+		const allowDuplication = false;
+
+		// when
+		const poll = await createPoll({
+			EventId,
+			pollName,
+			pollType,
+			selectionType,
+			allowDuplication,
+		});
+
+		// than
+		assert(poll.id > 0);
+		assert.equal(poll.EventId, EventId);
+		assert.equal(poll.pollName, pollName);
+		assert.equal(poll.pollType, pollType);
+		assert.equal(poll.selectionType, selectionType);
+		assert.equal(poll.allowDuplication, allowDuplication);
 	});
 });


### PR DESCRIPTION
* openPoll의 반환값을 number 타입으로 변경
* closePoll의 반환값을 number 타입으로 변경
* poll state string 을 상수화
* createPoll의 const 변수를 인자로 할당 받도록 변경
* 함수명 변경 createPoll -> createPollAndCandidate
* simplify logic of createPollAndCandidate
* createPollAndCandidate 함수에서 createPoll 함수 분리
* jsdoc 추가
* 테스트 추가
