### PR TITLE
fix and Enhance vote db query api

### DIFF
--- a/backend/DB/models/vote.js
+++ b/backend/DB/models/vote.js
@@ -2,14 +2,8 @@ import {Model} from "sequelize";
 
 export default class Vote extends Model {
 	static init(sequelize, DataTypes) {
-		return super.init(
+		const model = super.init(
 			{
-				id: {
-					allowNull: false,
-					autoIncrement: true,
-					primaryKey: true,
-					type: DataTypes.INTEGER,
-				},
 				createdAt: {
 					allowNull: false,
 					type: DataTypes.DATE,
@@ -21,6 +15,16 @@ export default class Vote extends Model {
 			},
 			{sequelize, tableName: "Votes"},
 		);
+
+		// Vote table is associate entity table primary key would be (GuestId, CandidateId)
+		// in sequelize, default primary key is 'id', so without remove attribute 'id' will
+		// occur error 'column 'id' not exist' in 'sqlite' dialect
+		// ref https://sequelize.org/master/manual/legacy.html
+		// Sequelize will assume your table has a id primary key property by default.
+		// And if your model has no primary key at all you can use Model.removeAttribute('id');
+		model.removeAttribute("id");
+
+		return model;
 	}
 
 	static associate(models) {

--- a/backend/DB/queries/vote.js
+++ b/backend/DB/queries/vote.js
@@ -7,15 +7,36 @@ const sequelize = models.sequelize;
 const Vote = models.Vote;
 const Op = Sequelize.Op;
 
-// todo add unit test
+
+/**
+ *
+ * @param GuestId {number|null}
+ * @param CandidateId {number|null}
+ * @return {Promise<object>}
+ */
 export async function addVote({GuestId, CandidateId}) {
-	return Vote.create({GuestId, CandidateId});
+	const result = await Vote.create({GuestId, CandidateId});
+
+	return result.get({plain: true});
 }
 
+/**
+ *
+ * @param GuestId {number|null}
+ * @param CandidateId {number|null}
+ * @return {Promise<number>} affected rows number
+ */
 export async function deleteVoteBy({GuestId, CandidateId}) {
 	return Vote.destroy({where: {GuestId, CandidateId}});
 }
 
+/**
+ *
+ * @param guestId {number|null}
+ * @param candidateToAdd {number|null}
+ * @param candidateToDelete {number|null}
+ * @return {Promise<number>} affected rows
+ */
 export async function addAndDelete(guestId, candidateToAdd, candidateToDelete) {
 	const GuestId = guestId;
 	let CandidateId = candidateToAdd;
@@ -59,8 +80,14 @@ export async function addAndDelete(guestId, candidateToAdd, candidateToDelete) {
 	return rows;
 }
 
+/**
+ *
+ * @param candidateList {number[]}
+ * @param guestId {number|null}
+ * @return {Promise<object[]>}
+ */
 export async function getCandidatesByGuestId(candidateList, guestId) {
-	return Vote.findAll({
+	const result = await Vote.findAll({
 		where: {
 			[Op.and]: [
 				{GuestId: guestId}, {
@@ -72,8 +99,15 @@ export async function getCandidatesByGuestId(candidateList, guestId) {
 		},
 		attributes: ["CandidateId"],
 	});
+
+	return result.map(x => x.get({plain: true}));
 }
 
+/**
+ *
+ * @param candidateList {number[]}
+ * @return {Promise<number>}
+ */
 export async function getVotersByCandidateList(candidateList) {
 	return Vote.count({
 		where: {

--- a/backend/graphQL/model/poll/pollGuest.resolver.js
+++ b/backend/graphQL/model/poll/pollGuest.resolver.js
@@ -3,7 +3,6 @@ import {
 	getCandidateList,
 	getCandidatesByPolls,
 	setPollItems,
-	simplifyList,
 } from "./resolveHelper.js";
 import {getPollsByEventId} from "../../../DB/queries/poll.js";
 import {POLL_TYPE_RATING} from "../../../constants/pollType.js";
@@ -46,7 +45,6 @@ async function setVotedOnPolls(polls, guestId) {
 		// eslint-disable-next-line no-await-in-loop
 		let votedList = await getCandidatesByGuestId(candidateList, guestId);
 
-		votedList = simplifyList(votedList);
 		votedList = votedList.map(n => n.CandidateId);
 		setVotedOnCandidate(poll, votedList);
 	}

--- a/backend/spec/DB/queries/vote.test.js
+++ b/backend/spec/DB/queries/vote.test.js
@@ -1,0 +1,188 @@
+import assert from "assert";
+import {before, beforeEach, describe, it} from "mocha";
+import models from "../../../DB/models";
+import {
+	addAndDelete,
+	addVote,
+	deleteVoteBy,
+	getCandidatesByGuestId,
+	getVotersByCandidateList,
+} from "../../../DB/queries/vote.js";
+import {createCandidate} from "../../../DB/queries/candidate.js";
+import {createGuest} from "../../../DB/queries/guest.js";
+
+describe("vote DB query api", () => {
+	const Vote = models.Vote;
+
+	before(async () => {
+		await models.sequelize.sync({force: true});
+	});
+
+	beforeEach(async () => {
+		await models.Vote.destroy({where: {}, truncate: true});
+	});
+
+	it(`should be able to ${addVote.name}`, async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		const PollId = null;
+		const content = "content";
+		const number = 3;
+		const candidate = await createCandidate({content, number, PollId});
+
+		const GuestId = guest.id;
+		const CandidateId = candidate.id;
+
+		// when
+		const vote = await addVote({GuestId, CandidateId});
+
+		// than
+		assert.equal(vote.CandidateId, CandidateId);
+		assert.equal(vote.GuestId, GuestId);
+	});
+
+	it(`should be able to ${deleteVoteBy.name}`, async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		const PollId = null;
+		const content = "content";
+		const number = 3;
+		const candidate = await createCandidate({content, number, PollId});
+
+		const GuestId = guest.id;
+		const CandidateId = candidate.id;
+
+		await addVote({GuestId, CandidateId});
+
+		// when
+		const result = await deleteVoteBy({GuestId, CandidateId});
+
+		// than
+		assert.equal(result, 1);
+
+		const expectAsNull = await Vote.findOne({
+			where: {GuestId, CandidateId},
+		});
+
+		assert.equal(expectAsNull, null);
+	});
+
+	it(`should be able to ${addAndDelete.name}`, async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		const PollId = null;
+		const content1 = "content1";
+		const number1 = 3;
+		const candidate1 = await createCandidate({
+			content: content1,
+			number: number1,
+			PollId,
+		});
+
+		const content2 = "content2";
+		const number2 = 3;
+		const candidate2 = await createCandidate({
+			content: content2,
+			number: number2,
+			PollId,
+		});
+
+		const GuestId = guest.id;
+		const CandidateIdToDelete = candidate1.id;
+		const CandidateIdToAdd = candidate2.id;
+
+		await addVote({GuestId, CandidateId: CandidateIdToDelete});
+
+		// when
+		const result = await addAndDelete(
+			GuestId,
+			CandidateIdToAdd,
+			CandidateIdToDelete,
+		);
+
+		// than
+		assert.equal(result, 1);
+
+		// expect create new vote
+		const createdVote = (
+			await Vote.findOne({
+				where: {GuestId, CandidateId: CandidateIdToAdd},
+			})
+		).get({plain: true});
+
+		assert.equal(createdVote.GuestId, GuestId);
+		assert.equal(createdVote.CandidateId, CandidateIdToAdd);
+
+		// expect delete old vote
+		const deletedVote = await Vote.findOne({
+			where: {GuestId, CandidateId: CandidateIdToDelete},
+		});
+
+		assert.equal(deletedVote, null);
+	});
+
+	it(`should be able to ${getCandidatesByGuestId.name}`, async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		const PollId = null;
+		const content1 = "content1";
+		const number1 = 3;
+		const candidate1 = await createCandidate({
+			content: content1,
+			number: number1,
+			PollId,
+		});
+
+		const GuestId = guest.id;
+		const CandidateIdToDelete = candidate1.id;
+
+		await addVote({GuestId, CandidateId: CandidateIdToDelete});
+
+		// when
+		const candidates = await getCandidatesByGuestId(
+			[CandidateIdToDelete],
+			GuestId,
+		);
+
+		// than
+		const expected = [{CandidateId: CandidateIdToDelete}];
+
+		assert.deepStrictEqual(candidates, expected);
+	});
+
+	it(`should be able to ${getVotersByCandidateList.name}`, async () => {
+		// given
+		const EventId = null;
+		const guest = await createGuest(EventId);
+
+		const PollId = null;
+		const content1 = "content1";
+		const number1 = 3;
+		const candidate1 = await createCandidate({
+			content: content1,
+			number: number1,
+			PollId,
+		});
+
+		const GuestId = guest.id;
+		const CandidateIdToDelete = candidate1.id;
+
+		await addVote({GuestId, CandidateId: CandidateIdToDelete});
+
+		// when
+		const voters = await getVotersByCandidateList([CandidateIdToDelete]);
+
+		// than
+		const expected = 1;
+
+		assert.equal(voters, expected);
+	});
+});


### PR DESCRIPTION
# fix: sequelize Vote model가 sqlite에서 column 'id' not exist error 해결

sequelize 에서는 디폴트으로 id를 primary key로 가지고, 연관 엔티티 테이블인 vote에서는 (CandidateId, GuestId)를 primary key로 가진다.
이때 sequelize 객체 모델에서는 'id'가 존재하지만 DB 테이블상에서는 존재하지 않는다. mysql에서는 문제 없었지만, 테스트용 sqlite3에서는 문제가 발생한다.
그래서 model.removeAttribute("id"); 로 sequelize 객체상에서 삭제하여 해결한다.

# enhance: add test of vote db query api
* addVote, getCandidatesByGuestId의 반환값을 plain js object 형태로 변경
* jsdoc 추가
* 단위 테스트 추가