### PR TITLE
Refactoring minor

### DIFF
--- a/backend/socket_io_server/socketHandler/Vote/rateOff.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Vote/rateOff.socketHandler.js
@@ -10,9 +10,7 @@ const rateOffSocketHandler = async (data, emit) => {
 	try {
 		const {GuestId, CandidateId, poll, index} = data;
 
-		await deleteVoteBy({GuestId, CandidateId});
-
-		await updateVoters(poll);
+		await Promise.all([deleteVoteBy({GuestId, CandidateId}), updateVoters(poll)]);
 
 		emit({
 			status: SOCKET_IO_RESPONSE_STATE_OK,

--- a/backend/socket_io_server/socketHandler/Vote/rateOn.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Vote/rateOn.socketHandler.js
@@ -10,9 +10,7 @@ const rateOnSocketHandler = async (data, emit) => {
 	try {
 		const {GuestId, CandidateId, poll, index} = data;
 
-		await addVote({GuestId, CandidateId});
-
-		await updateVoters(poll);
+		await Promise.all([addVote({GuestId, CandidateId}), updateVoters(poll)]);
 
 		emit({
 			status: SOCKET_IO_RESPONSE_STATE_OK,

--- a/backend/socket_io_server/socketHandler/Vote/voteOff.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Vote/voteOff.socketHandler.js
@@ -10,9 +10,7 @@ const voteOffSocketHandler = async (data, emit) => {
 	try {
 		const {GuestId, CandidateId, poll} = data;
 
-		await deleteVoteBy({GuestId, CandidateId});
-
-		await updateVoters(poll);
+		await Promise.all([deleteVoteBy({GuestId, CandidateId}), updateVoters(poll)]);
 
 		emit({
 			status: SOCKET_IO_RESPONSE_STATE_OK,

--- a/backend/socket_io_server/socketHandler/Vote/voteOn.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Vote/voteOn.socketHandler.js
@@ -16,13 +16,21 @@ const voteOnSocketHandler = async (data, emit) => {
 			candidateToDelete,
 		} = data;
 
+		let updateVotePromise;
+
 		if (!allowDuplication && candidateToDelete) {
-			await addAndDelete(GuestId, CandidateId, candidateToDelete);
+			updateVotePromise = addAndDelete(
+				GuestId,
+				CandidateId,
+				candidateToDelete,
+			);
 		} else {
-			await addVote({GuestId, CandidateId});
+			updateVotePromise = addVote({GuestId, CandidateId});
 		}
 
-		await updateVoters(poll);
+		const updateVotersPromise = updateVoters(poll);
+
+		await Promise.all([updateVotePromise, updateVotersPromise]);
 
 		emit({
 			status: SOCKET_IO_RESPONSE_STATE_OK,

--- a/backend/socket_io_server/socketHandler/Vote/voteOn.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Vote/voteOn.socketHandler.js
@@ -1,4 +1,4 @@
-import {addAndDelete, addVote} from "../../../DB/queries/vote";
+import {swapVoteByGuestId, addVote} from "../../../DB/queries/vote";
 import updateVoters from "./updateVoters";
 import logger from "../../logger.js";
 import {
@@ -19,7 +19,7 @@ const voteOnSocketHandler = async (data, emit) => {
 		let updateVotePromise;
 
 		if (!allowDuplication && candidateToDelete) {
-			updateVotePromise = addAndDelete(
+			updateVotePromise = swapVoteByGuestId(
 				GuestId,
 				CandidateId,
 				candidateToDelete,

--- a/backend/spec/DB/queries/vote.test.js
+++ b/backend/spec/DB/queries/vote.test.js
@@ -2,11 +2,11 @@ import assert from "assert";
 import {before, beforeEach, describe, it} from "mocha";
 import models from "../../../DB/models";
 import {
-	addAndDelete,
 	addVote,
 	deleteVoteBy,
 	getCandidatesByGuestId,
 	getVotersByCandidateList,
+	swapVoteByGuestId,
 } from "../../../DB/queries/vote.js";
 import {createCandidate} from "../../../DB/queries/candidate.js";
 import {createGuest} from "../../../DB/queries/guest.js";
@@ -71,7 +71,7 @@ describe("vote DB query api", () => {
 		assert.equal(expectAsNull, null);
 	});
 
-	it(`should be able to ${addAndDelete.name}`, async () => {
+	it(`should be able to ${swapVoteByGuestId.name}`, async () => {
 		// given
 		const EventId = null;
 		const guest = await createGuest(EventId);
@@ -97,17 +97,20 @@ describe("vote DB query api", () => {
 		const CandidateIdToDelete = candidate1.id;
 		const CandidateIdToAdd = candidate2.id;
 
-		await addVote({GuestId, CandidateId: CandidateIdToDelete});
+		const vote = await addVote({GuestId, CandidateId: CandidateIdToDelete});
 
 		// when
-		const result = await addAndDelete(
+		const swappedVote = await swapVoteByGuestId(
 			GuestId,
 			CandidateIdToAdd,
 			CandidateIdToDelete,
 		);
 
 		// than
-		assert.equal(result, 1);
+		// expect swapped vote should be update CandidateId only
+		assert.equal(swappedVote.CandidateId, CandidateIdToAdd);
+		assert.equal(swappedVote.GuestId, GuestId);
+		assert.deepStrictEqual(swappedVote.createdAt, vote.createdAt);
 
 		// expect create new vote
 		const createdVote = (


### PR DESCRIPTION
# refactoring: merge await able object to Promise.all

* 동시 실행가능한 비동기처리 부분을 promise.all 로 변경

# refactoring: function addAndDelete in DB query api 

* 함수 로직 변경
  DB row create and delete -> find and update 방식으로 변경

* 함수 예외처리 변경
  row find시 row가 없는 경우 에러 발생하도록 변경
  에러처리시 catch 에서 transaction rollback 이후 에러를 발생하도록 변경

* 함수이름 변경
   addAndDelete -> swapVoteByGuestId

* 함수 인자 이름 변경
   candidateToAdd -> newCandidateId
   candidateToDelete -> oldCandidateId

* 반환 타입 변경
  영향받은 table rows -> 업데이트된 row object

* by cascade update test and real usage