### PR TITLE
Graphql test

### DIFF
--- a/backend/spec/graphql/guest.test.js
+++ b/backend/spec/graphql/guest.test.js
@@ -191,6 +191,8 @@ describe("graphql yoga guest model", () => {
 		} = res;
 
 		// than
+		// todo: 일관적이지 않은 graphql type 해결하기
+		// pk, fk 인 id 값이 number 와 string 이 혼용됨
 		const expected = {
 			event: {
 				id: event.id,

--- a/backend/spec/graphql/guest.test.js
+++ b/backend/spec/graphql/guest.test.js
@@ -1,29 +1,92 @@
 import assert from "assert";
-import {after, before, describe, it} from "mocha";
-import GQLClient from "../testHelper/graphqlTestClient.js";
+import EasyGraphQLTester from "easygraphql-tester";
+import {after, before, beforeEach, describe, it} from "mocha";
+import guestResolvers from "../../graphQL/model/guest/guest.resolver.js";
+import SequelizeTestHelper from "../testHelper/SequelizeTestHelper.js";
 import typeDefs from "../../graphQL/typeDefs.js";
 import resolvers from "../../graphQL/resolvers.js";
-import config from "../../graphQL/config.js";
-import GQLServerTestHelper from "../testHelper/GQLServerTestHelper.js";
-import SequelizeTestHelper from "../testHelper/SequelizeTestHelper.js";
+import models from "../../DB/models";
+import {createGuest} from "../../DB/queries/guest.js";
+import {createEvent} from "../../DB/queries/event.js";
 
 describe("graphql yoga guest model", () => {
-	const gqlServerMock = new GQLServerTestHelper({
-		typeDefs,
-		resolvers,
-		config,
-	});
 	const sequelizeMock = new SequelizeTestHelper();
 
+	let gqlTester = null;
+
 	before(async () => {
-		await Promise.all([gqlServerMock.setup(), sequelizeMock.setup()]);
+		await Promise.all([sequelizeMock.setup()]);
+
+		gqlTester = new EasyGraphQLTester(typeDefs, resolvers);
 	});
 
 	after(async () => {
-		await Promise.all([gqlServerMock.teardown(), sequelizeMock.teardown()]);
+		await Promise.all([sequelizeMock.teardown()]);
 	});
 
-	it("able query guest", async () => {
+	beforeEach(async () => {
+		models.Event.destroy({
+			where: {},
+			truncate: true,
+		});
+		models.Guest.destroy({
+			where: {},
+			truncate: true,
+		});
+	});
+
+	it("should able to query 'guests'", async () => {
+		const HostId = null;
+		const eventName = "eventName";
+		const eventCode = "eventCord";
+		const event = await createEvent({eventCode, eventName, HostId});
+
+		const EventId = event.id;
+		const guest = await createGuest(EventId);
+
+		const root = null;
+		const context = null;
+		const query = `
+		query getGuests(
+			$EventId: ID!
+		){
+			guests(EventId: $EventId) {
+				id
+				name
+				isAnonymous
+				company
+				email
+			}
+		}
+		`;
+
+		const variables = {
+			EventId,
+		};
+
+		let res = await gqlTester.graphql(query, root, context, variables);
+
+		// to remove [Object: null prototype]
+		res = JSON.parse(JSON.stringify(res));
+
+		const {
+			data: {guests: realGuests},
+		} = res;
+
+		const expected = [
+			{
+				company: null,
+				email: null,
+				id: guest.id.toString(),
+				isAnonymous: guest.isAnonymous,
+				name: guest.name,
+			},
+		];
+
+		assert.deepStrictEqual(realGuests, expected);
+	});
+
+	it("should be able to pass schema test 'query guests'", async () => {
 		const query = `
 		query getGuests(
 			$EventId: ID!
@@ -42,8 +105,25 @@ describe("graphql yoga guest model", () => {
 			EventId: 2,
 		};
 
-		await GQLClient.request(query, variables);
+		await gqlTester.test(true, query, variables);
+	});
 
-		assert(false);
+	it("should be able to resolve 'guests' by resolver", async () => {
+		// given
+		const HostId = null;
+		const eventName = "eventName";
+		const eventCode = "eventCord";
+		const event = await createEvent({eventCode, eventName, HostId});
+
+		const EventId = event.id;
+		const guest = await createGuest(EventId);
+
+		// when
+		const real = await guestResolvers.Query.guests(null, {EventId});
+
+		// than
+		const expected = [guest];
+
+		assert.deepStrictEqual(real, expected);
 	});
 });


### PR DESCRIPTION
# add test of graphql guest model
* test of graphql `guests` query
* test of graphql `guestInEvent` query
 
# chore
chore: add todo: 일관적이지 않은 graphql type 해결하기

graphql에서 result로 반환된 값 중 pk, fk 인 id 값이 number 와 string 이 혼용됨 