### PR TITLE
add graphql test and ETC

### DIFF
--- a/backend/DB/queries/event.js
+++ b/backend/DB/queries/event.js
@@ -21,6 +21,7 @@ export async function getAllEvents() {
  * @param endAt {Date}
  * @returns {Promise<object>}
  */
+// todo: rename to findOrCreateEvent
 export async function createEvent({
 	eventName,
 	eventCode,

--- a/backend/graphQL/model/hostpage/hostpage.resolver.js
+++ b/backend/graphQL/model/hostpage/hostpage.resolver.js
@@ -104,9 +104,7 @@ const updateEventResolver = async (_, {event}, authority) => {
 		endAt: event.endAt,
 	});
 
-	const updatedEvent = await getEventById(event.EventId);
-
-	return updatedEvent.get({plain: true});
+	return getEventById(event.EventId);
 };
 
 // noinspection JSUnusedGlobalSymbols

--- a/backend/graphQL/model/hostpage/hostpage.resolver.js
+++ b/backend/graphQL/model/hostpage/hostpage.resolver.js
@@ -69,6 +69,7 @@ const initQueryResolver = async (_, {param}, authority) => {
 	return {events, host};
 };
 
+// todo: resolver의 return 값 및 해당 scheme의 return type refactoring 필요
 const createHashTagsResolver = async (_, {hashTags}, authority) => {
 	verifySubjectHostJwt(authority.sub);
 	// todo fix to bulk insert

--- a/backend/spec/graphql/emoji.test.js
+++ b/backend/spec/graphql/emoji.test.js
@@ -1,5 +1,6 @@
 import assert from "assert";
 import {after, before, beforeEach, describe, it} from "mocha";
+import gql from "graphql-tag";
 import EasyGraphQLTester from "easygraphql-tester";
 import emojiResolvers from "../../graphQL/model/emoji/emoji.resolver.js";
 import typeDefs from "../../graphQL/typeDefs.js";
@@ -50,15 +51,15 @@ describe("graphql yoga emoji model", () => {
 		const emoji = await createEmoji({GuestId, QuestionId, name, EventId});
 
 		// gql input
-		const query = `
-			query get_emojis($EventId: ID!) {
-				emojis(EventId: $EventId) {
-					name
-					count
-					QuestionId
-					createdAt
-				}
-			}
+		const query = gql`
+            query get_emojis($EventId: ID!) {
+                emojis(EventId: $EventId) {
+                    name
+                    count
+                    QuestionId
+                    createdAt
+                }
+            }
 		`;
 		const variables = {
 			EventId,
@@ -90,14 +91,14 @@ describe("graphql yoga emoji model", () => {
 	});
 
 	it("should be able to pass schema test 'query emojis'", async () => {
-		const query = `
-			query query_emojis($EventId: ID!) {
-				emojis(EventId: $EventId) {
-					name
-					count
-					QuestionId
-				}
-			}
+		const query = gql`
+            query query_emojis($EventId: ID!) {
+                emojis(EventId: $EventId) {
+                    name
+                    count
+                    QuestionId
+                }
+            }
 		`;
 
 		const variables = {
@@ -152,13 +153,13 @@ describe("graphql yoga emoji model", () => {
 
 		await createEmoji({GuestId, QuestionId, name, EventId});
 
-		const query = `
-			query get_emojipicks($EventId: ID!, $GuestId: ID!) {
-				emojiPicks(EventId: $EventId, GuestId: $GuestId) {
-					name
-					QuestionId
-				}
-			}
+		const query = gql`
+            query get_emojipicks($EventId: ID!, $GuestId: ID!) {
+                emojiPicks(EventId: $EventId, GuestId: $GuestId) {
+                    name
+                    QuestionId
+                }
+            }
 		`;
 		const variables = {
 			EventId,
@@ -177,13 +178,13 @@ describe("graphql yoga emoji model", () => {
 	});
 
 	it("should be able to pass schema test 'query emojiPicks'", async () => {
-		const query = `
-			query get_emojipicks($EventId: ID!, $GuestId: ID!) {
-				emojiPicks(EventId: $EventId, GuestId: $GuestId) {
-					name
-					QuestionId
-				}
-			}
+		const query = gql`
+            query get_emojipicks($EventId: ID!, $GuestId: ID!) {
+                emojiPicks(EventId: $EventId, GuestId: $GuestId) {
+                    name
+                    QuestionId
+                }
+            }
 		`;
 
 		const variables = {

--- a/backend/spec/graphql/guest.test.js
+++ b/backend/spec/graphql/guest.test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import gql from "graphql-tag";
 import EasyGraphQLTester from "easygraphql-tester";
 import {after, before, beforeEach, describe, it} from "mocha";
 import guestResolvers from "../../graphQL/model/guest/guest.resolver.js";
@@ -52,18 +53,18 @@ describe("graphql yoga guest model", () => {
 
 		const root = null;
 		const context = null;
-		const query = `
-		query getGuests(
-			$EventId: ID!
-		){
-			guests(EventId: $EventId) {
-				id
-				name
-				isAnonymous
-				company
-				email
-			}
-		}
+		const query = gql`
+            query getGuests(
+                $EventId: ID!
+            ){
+                guests(EventId: $EventId) {
+                    id
+                    name
+                    isAnonymous
+                    company
+                    email
+                }
+            }
 		`;
 
 		const variables = {
@@ -93,18 +94,18 @@ describe("graphql yoga guest model", () => {
 	});
 
 	it("should be able to pass schema test 'query guests'", async () => {
-		const query = `
-		query getGuests(
-			$EventId: ID!
-		){
-			guests(EventId: $EventId) {
-				id
-				name
-				isAnonymous
-				company
-				email
-			}
-		}
+		const query = gql`
+            query getGuests(
+                $EventId: ID!
+            ){
+                guests(EventId: $EventId) {
+                    id
+                    name
+                    isAnonymous
+                    company
+                    email
+                }
+            }
 		`;
 
 		const variables = {
@@ -160,25 +161,25 @@ describe("graphql yoga guest model", () => {
 		// when
 		const root = null;
 		const context = authority;
-		const query = `
-		query {
-			guestInEvent {
-				event {
-					id
-					eventCode
-					startAt
-					endAt
-					eventName
-					HostId
-				}
-				guest {
-					id
-					name
-					email
-					company
-				}
-			}
-		}
+		const query = gql`
+            query {
+                guestInEvent {
+                    event {
+                        id
+                        eventCode
+                        startAt
+                        endAt
+                        eventName
+                        HostId
+                    }
+                    guest {
+                        id
+                        name
+                        email
+                        company
+                    }
+                }
+            }
 		`;
 		const variables = {};
 		let res = await gqlTester.graphql(query, root, context, variables);
@@ -214,25 +215,25 @@ describe("graphql yoga guest model", () => {
 	});
 
 	it("should be able to pass schema test 'query guestInEvent'", async () => {
-		const query = `
-		query {
-			guestInEvent {
-				event {
-					id
-					eventCode
-					startAt
-					endAt
-					eventName
-					HostId
-				}
-				guest {
-					id
-					name
-					email
-					company
-				}
-			}
-		}
+		const query = gql`
+            query {
+                guestInEvent {
+                    event {
+                        id
+                        eventCode
+                        startAt
+                        endAt
+                        eventName
+                        HostId
+                    }
+                    guest {
+                        id
+                        name
+                        email
+                        company
+                    }
+                }
+            }
 		`;
 
 		const variables = {

--- a/backend/spec/graphql/hostpage.test.js
+++ b/backend/spec/graphql/hostpage.test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import gql from "graphql-tag";
 import {after, before, beforeEach, describe, it} from "mocha";
 import EasyGraphQLTester from "easygraphql-tester";
 import typeDefs from "../../graphQL/typeDefs.js";
@@ -79,38 +80,38 @@ describe("graphql yoga hostpage model", () => {
 		const GuestId = null;
 
 		// gql input
-		const query = `
-			query get_init {
-				init {
-					host {
-						id
-						oauthId
-						name
-						email
-						emailFeedBack
-						image
-					}
-					events {
-						id
-						eventCode
-						eventName
-						moderationOption
-						replyOption
-						createdAt
-						updatedAt
-						startAt
-						endAt
-						HostId
-						HashTags {
-							id
-							name
-							createdAt
-							updatedAt
-							EventId
-						}
-					}
-				}
-			}
+		const query = gql`
+            query get_init {
+                init {
+                    host {
+                        id
+                        oauthId
+                        name
+                        email
+                        emailFeedBack
+                        image
+                    }
+                    events {
+                        id
+                        eventCode
+                        eventName
+                        moderationOption
+                        replyOption
+                        createdAt
+                        updatedAt
+                        startAt
+                        endAt
+                        HostId
+                        HashTags {
+                            id
+                            name
+                            createdAt
+                            updatedAt
+                            EventId
+                        }
+                    }
+                }
+            }
 		`;
 		const variables = {
 			GuestId,
@@ -187,43 +188,43 @@ describe("graphql yoga hostpage model", () => {
 	});
 
 	it("should be able to pass schema test 'query init'", async () => {
-		const query = `
-			query get_init {
-				init {
-					host {
-						id
-						oauthId
-						name
-						email
-						emailFeedBack
-						image
-					}
-					events {
-						id
-						eventCode
-						eventName
-						moderationOption
-						replyOption
-						createdAt
-						updatedAt
-						startAt
-						endAt
-						HostId
-						HashTags {
-							id
-							name
-							createdAt
-							updatedAt
-							EventId
-						}
-					}
-				}
-			}
+		const query = gql`
+            query get_init {
+                init {
+                    host {
+                        id
+                        oauthId
+                        name
+                        email
+                        emailFeedBack
+                        image
+                    }
+                    events {
+                        id
+                        eventCode
+                        eventName
+                        moderationOption
+                        replyOption
+                        createdAt
+                        updatedAt
+                        startAt
+                        endAt
+                        HostId
+                        HashTags {
+                            id
+                            name
+                            createdAt
+                            updatedAt
+                            EventId
+                        }
+                    }
+                }
+            }
 		`;
 
 		const variables = {};
 
-		await gqlTester.test(true, query.toString(), variables);
+		await gqlTester.test(true, query, variables);
 	});
 
 	it("should be able to resolve 'init' by resolver", async () => {
@@ -283,13 +284,13 @@ describe("graphql yoga hostpage model", () => {
 			HostId,
 		});
 		// gql input
-		const query = `
-			query get_init($EventId: ID!) {
-				getEventOption(EventId: $EventId) {
-					moderationOption
-					replyOption
-				}
-			}
+		const query = gql`
+            query get_init($EventId: ID!) {
+                getEventOption(EventId: $EventId) {
+                    moderationOption
+                    replyOption
+                }
+            }
 		`;
 		const variables = {
 			EventId: event1.id,
@@ -318,20 +319,20 @@ describe("graphql yoga hostpage model", () => {
 	});
 
 	it("should be able to pass schema test 'query getEventOption'", async () => {
-		const query = `
-			query get_init($EventId: ID!) {
-				getEventOption(EventId: $EventId) {
-					moderationOption
-					replyOption
-				}
-			}
+		const query = gql`
+            query get_init($EventId: ID!) {
+                getEventOption(EventId: $EventId) {
+                    moderationOption
+                    replyOption
+                }
+            }
 		`;
 
 		const variables = {
 			EventId: 2,
 		};
 
-		await gqlTester.test(true, query.toString(), variables);
+		await gqlTester.test(true, query, variables);
 	});
 
 	it("should be able to resolve 'getEventOption' by resolver", async () => {
@@ -383,16 +384,16 @@ describe("graphql yoga hostpage model", () => {
 		const hashTags = [{name: hashTagName, EventId}];
 
 		// gql input
-		const query = `
-			mutation Mutation($hashTags: [HashTagInput]!) {
-				createHashTags(hashTags: $hashTags) {
-					id
-					name
-					createdAt
-					updatedAt
-					EventId
-				}
-			}
+		const query = gql`
+            mutation Mutation($hashTags: [HashTagInput]!) {
+                createHashTags(hashTags: $hashTags) {
+                    id
+                    name
+                    createdAt
+                    updatedAt
+                    EventId
+                }
+            }
 		`;
 		const variables = {
 			hashTags,
@@ -417,23 +418,23 @@ describe("graphql yoga hostpage model", () => {
 	});
 
 	it("should be able to pass schema test 'mutate createHashTags'", async () => {
-		const query = `
-			mutation Mutation($hashTags: [HashTagInput]!) {
-				createHashTags(hashTags: $hashTags) {
-					id
-					name
-					createdAt
-					updatedAt
-					EventId
-				}
-			}
+		const query = gql`
+            mutation Mutation($hashTags: [HashTagInput]!) {
+                createHashTags(hashTags: $hashTags) {
+                    id
+                    name
+                    createdAt
+                    updatedAt
+                    EventId
+                }
+            }
 		`;
 
 		const variables = {
 			hashTags: [{name: "name", EventId: 2}],
 		};
 
-		await gqlTester.test(true, query.toString(), variables);
+		await gqlTester.test(true, query, variables);
 	});
 
 	it("should be able to resolve 'createHashTags' by resolver", async () => {
@@ -497,19 +498,19 @@ describe("graphql yoga hostpage model", () => {
 		};
 
 		// gql input
-		const query = `
-			mutation Query($info: EventInfo!) {
-				createEvent(info: $info) {
-					id
-					eventCode
-					eventName
-					moderationOption
-					replyOption
-					endAt
-					startAt
-					HostId
-				}
-			}
+		const query = gql`
+            mutation Query($info: EventInfo!) {
+                createEvent(info: $info) {
+                    id
+                    eventCode
+                    eventName
+                    moderationOption
+                    replyOption
+                    endAt
+                    startAt
+                    HostId
+                }
+            }
 		`;
 		const variables = {
 			info,
@@ -542,19 +543,19 @@ describe("graphql yoga hostpage model", () => {
 	});
 
 	it("should be able to pass schema test 'mutate createEvent'", async () => {
-		const query = `
-			mutation Query($info: EventInfo!) {
-				createEvent(info: $info) {
-					id
-					eventCode
-					eventName
-					moderationOption
-					replyOption
-					endAt
-					startAt
-					HostId
-				}
-			}
+		const query = gql`
+            mutation Query($info: EventInfo!) {
+                createEvent(info: $info) {
+                    id
+                    eventCode
+                    eventName
+                    moderationOption
+                    replyOption
+                    endAt
+                    startAt
+                    HostId
+                }
+            }
 		`;
 
 		const variables = {
@@ -566,7 +567,7 @@ describe("graphql yoga hostpage model", () => {
 			},
 		};
 
-		await gqlTester.test(true, query.toString(), variables);
+		await gqlTester.test(true, query, variables);
 	});
 
 	it("should be able to resolve 'createEvent' by resolver", async () => {

--- a/backend/spec/graphql/hostpage.test.js
+++ b/backend/spec/graphql/hostpage.test.js
@@ -81,37 +81,37 @@ describe("graphql yoga hostpage model", () => {
 
 		// gql input
 		const query = gql`
-            query get_init {
-                init {
-                    host {
-                        id
-                        oauthId
-                        name
-                        email
-                        emailFeedBack
-                        image
-                    }
-                    events {
-                        id
-                        eventCode
-                        eventName
-                        moderationOption
-                        replyOption
-                        createdAt
-                        updatedAt
-                        startAt
-                        endAt
-                        HostId
-                        HashTags {
-                            id
-                            name
-                            createdAt
-                            updatedAt
-                            EventId
-                        }
-                    }
-                }
-            }
+			query get_init {
+				init {
+					host {
+						id
+						oauthId
+						name
+						email
+						emailFeedBack
+						image
+					}
+					events {
+						id
+						eventCode
+						eventName
+						moderationOption
+						replyOption
+						createdAt
+						updatedAt
+						startAt
+						endAt
+						HostId
+						HashTags {
+							id
+							name
+							createdAt
+							updatedAt
+							EventId
+						}
+					}
+				}
+			}
 		`;
 		const variables = {
 			GuestId,
@@ -189,37 +189,37 @@ describe("graphql yoga hostpage model", () => {
 
 	it("should be able to pass schema test 'query init'", async () => {
 		const query = gql`
-            query get_init {
-                init {
-                    host {
-                        id
-                        oauthId
-                        name
-                        email
-                        emailFeedBack
-                        image
-                    }
-                    events {
-                        id
-                        eventCode
-                        eventName
-                        moderationOption
-                        replyOption
-                        createdAt
-                        updatedAt
-                        startAt
-                        endAt
-                        HostId
-                        HashTags {
-                            id
-                            name
-                            createdAt
-                            updatedAt
-                            EventId
-                        }
-                    }
-                }
-            }
+			query get_init {
+				init {
+					host {
+						id
+						oauthId
+						name
+						email
+						emailFeedBack
+						image
+					}
+					events {
+						id
+						eventCode
+						eventName
+						moderationOption
+						replyOption
+						createdAt
+						updatedAt
+						startAt
+						endAt
+						HostId
+						HashTags {
+							id
+							name
+							createdAt
+							updatedAt
+							EventId
+						}
+					}
+				}
+			}
 		`;
 
 		const variables = {};
@@ -285,12 +285,12 @@ describe("graphql yoga hostpage model", () => {
 		});
 		// gql input
 		const query = gql`
-            query get_init($EventId: ID!) {
-                getEventOption(EventId: $EventId) {
-                    moderationOption
-                    replyOption
-                }
-            }
+			query get_init($EventId: ID!) {
+				getEventOption(EventId: $EventId) {
+					moderationOption
+					replyOption
+				}
+			}
 		`;
 		const variables = {
 			EventId: event1.id,
@@ -320,12 +320,12 @@ describe("graphql yoga hostpage model", () => {
 
 	it("should be able to pass schema test 'query getEventOption'", async () => {
 		const query = gql`
-            query get_init($EventId: ID!) {
-                getEventOption(EventId: $EventId) {
-                    moderationOption
-                    replyOption
-                }
-            }
+			query get_init($EventId: ID!) {
+				getEventOption(EventId: $EventId) {
+					moderationOption
+					replyOption
+				}
+			}
 		`;
 
 		const variables = {
@@ -385,15 +385,15 @@ describe("graphql yoga hostpage model", () => {
 
 		// gql input
 		const query = gql`
-            mutation Mutation($hashTags: [HashTagInput]!) {
-                createHashTags(hashTags: $hashTags) {
-                    id
-                    name
-                    createdAt
-                    updatedAt
-                    EventId
-                }
-            }
+			mutation Mutation($hashTags: [HashTagInput]!) {
+				createHashTags(hashTags: $hashTags) {
+					id
+					name
+					createdAt
+					updatedAt
+					EventId
+				}
+			}
 		`;
 		const variables = {
 			hashTags,
@@ -419,15 +419,15 @@ describe("graphql yoga hostpage model", () => {
 
 	it("should be able to pass schema test 'mutate createHashTags'", async () => {
 		const query = gql`
-            mutation Mutation($hashTags: [HashTagInput]!) {
-                createHashTags(hashTags: $hashTags) {
-                    id
-                    name
-                    createdAt
-                    updatedAt
-                    EventId
-                }
-            }
+			mutation Mutation($hashTags: [HashTagInput]!) {
+				createHashTags(hashTags: $hashTags) {
+					id
+					name
+					createdAt
+					updatedAt
+					EventId
+				}
+			}
 		`;
 
 		const variables = {
@@ -499,18 +499,18 @@ describe("graphql yoga hostpage model", () => {
 
 		// gql input
 		const query = gql`
-            mutation Query($info: EventInfo!) {
-                createEvent(info: $info) {
-                    id
-                    eventCode
-                    eventName
-                    moderationOption
-                    replyOption
-                    endAt
-                    startAt
-                    HostId
-                }
-            }
+			mutation Query($info: EventInfo!) {
+				createEvent(info: $info) {
+					id
+					eventCode
+					eventName
+					moderationOption
+					replyOption
+					endAt
+					startAt
+					HostId
+				}
+			}
 		`;
 		const variables = {
 			info,
@@ -544,18 +544,18 @@ describe("graphql yoga hostpage model", () => {
 
 	it("should be able to pass schema test 'mutate createEvent'", async () => {
 		const query = gql`
-            mutation Query($info: EventInfo!) {
-                createEvent(info: $info) {
-                    id
-                    eventCode
-                    eventName
-                    moderationOption
-                    replyOption
-                    endAt
-                    startAt
-                    HostId
-                }
-            }
+			mutation Query($info: EventInfo!) {
+				createEvent(info: $info) {
+					id
+					eventCode
+					eventName
+					moderationOption
+					replyOption
+					endAt
+					startAt
+					HostId
+				}
+			}
 		`;
 
 		const variables = {
@@ -604,6 +604,145 @@ describe("graphql yoga hostpage model", () => {
 		// than
 		assert.equal(result.eventName, eventName);
 		assert.equal(result.HostId, HostId);
+		assert.equal(result.startAt.toISOString(), startAt);
+		assert.equal(result.endAt.toISOString(), endAt);
+	});
+
+	it("should be able to mutate 'updateEvent'", async () => {
+		// given
+		const host = await findOrCreateHostByOAuth({
+			oauthId: "oauthId",
+			email: "email",
+			image: "image",
+			name: "host name",
+		});
+		const HostId = host.id;
+		const eventName = "eventName";
+		const eventCode = "eventCode";
+
+		const event = await createEvent({eventName, eventCode, HostId});
+		const EventId = event.id;
+
+		const startAt = new Date().toISOString();
+		const endAt = new Date().toISOString();
+
+		// gql input
+		const query = gql`
+			mutation Mutation($event: EventUpdate!) {
+				updateEvent(event: $event) {
+					id
+					eventCode
+					eventName
+					moderationOption
+					replyOption
+					endAt
+					startAt
+					HostId
+				}
+			}
+		`;
+		const variables = {
+			event: {
+				EventId,
+				eventName,
+				startAt,
+				endAt,
+			},
+		};
+		const context = {sub: AUTHORITY_TYPE_HOST, info: host};
+		const root = null;
+
+		// when
+		let gqlResult = await gqlTester.graphql(
+			query,
+			root,
+			context,
+			variables,
+		);
+
+		// to remove [Object: null prototype]
+		gqlResult = JSON.parse(JSON.stringify(gqlResult));
+
+		const {
+			data: {updateEvent: result},
+		} = gqlResult;
+
+		assert.equal(result.eventName, eventName);
+		assert.equal(result.HostId, HostId);
+		assert.equal(result.id, EventId);
+		assert.equal(
+			new Date(parseInt(result.startAt, 10)).toISOString(),
+			startAt,
+		);
+		assert.equal(new Date(parseInt(result.endAt, 10)).toISOString(), endAt);
+	});
+
+	it("should be able to pass schema test 'mutate updateEvent'", async () => {
+		const query = gql`
+			mutation Mutation($event: EventUpdate!) {
+				updateEvent(event: $event) {
+					id
+					eventCode
+					eventName
+					moderationOption
+					replyOption
+					endAt
+					startAt
+					HostId
+				}
+			}
+		`;
+
+		const variables = {
+			event: {
+				EventId: 0,
+				eventName: "eventName",
+				startAt: "startAt",
+				endAt: "endAt",
+			},
+		};
+
+		await gqlTester.test(true, query, variables);
+	});
+
+	it("should be able to resolve 'updateEvent' by resolver", async () => {
+		// given
+		const host = await findOrCreateHostByOAuth({
+			oauthId: "oauthId",
+			email: "email",
+			image: "image",
+			name: "host name",
+		});
+		const HostId = host.id;
+		const eventName = "eventName";
+		const eventCode = "eventCode";
+
+		const event = await createEvent({eventName, eventCode, HostId});
+		const EventId = event.id;
+
+		const startAt = new Date().toISOString();
+		const endAt = new Date().toISOString();
+
+		const context = {sub: AUTHORITY_TYPE_HOST, info: host};
+
+		// when
+		const result = await hostpageResolvers.Mutation.updateEvent(
+			null,
+			{
+				event: {
+					EventId,
+					eventName,
+					startAt,
+					endAt,
+				},
+			},
+			context,
+		);
+
+		// than
+		assert.equal(result.eventName, eventName);
+		assert.equal(result.HostId, HostId);
+		assert.equal(result.id, EventId);
 		assert.equal(result.startAt.toISOString(), startAt);
 		assert.equal(result.endAt.toISOString(), endAt);
 	});

--- a/backend/spec/graphql/like.test.js
+++ b/backend/spec/graphql/like.test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import gql from "graphql-tag";
 import {after, before, beforeEach, describe, it} from "mocha";
 import EasyGraphQLTester from "easygraphql-tester";
 import typeDefs from "../../graphQL/typeDefs.js";
@@ -57,14 +58,12 @@ describe("graphql yoga like model", () => {
 		const like = await createLike({GuestId, QuestionId});
 
 		// gql input
-		const query = `
-			query get_didILikes(
-				$GuestId: ID!
-			) {
-				didILikes(GuestId: $GuestId) {
-					QuestionId  
-				}
-			}
+		const query = gql`
+            query get_didILikes($GuestId: ID!) {
+                didILikes(GuestId: $GuestId) {
+                    QuestionId
+                }
+            }
 		`;
 		const variables = {
 			GuestId,
@@ -93,14 +92,12 @@ describe("graphql yoga like model", () => {
 	});
 
 	it("should be able to pass schema test 'query didILikes'", async () => {
-		const query = `
-			query get_didILikes(
-			$GuestId: ID!
-		){
-			didILikes(GuestId: $GuestId) {
-				QuestionId  
-			}
-		}
+		const query = gql`
+            query get_didILikes($GuestId: ID!) {
+                didILikes(GuestId: $GuestId) {
+                    QuestionId
+                }
+            }
 		`;
 
 		const variables = {

--- a/backend/spec/graphql/question.test.js
+++ b/backend/spec/graphql/question.test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import gql from "graphql-tag";
 import EasyGraphQLTester from "easygraphql-tester";
 import {after, before, beforeEach, describe, it} from "mocha";
 import typeDefs from "../../graphQL/typeDefs.js";
@@ -57,20 +58,20 @@ describe("graphql yoga question model", () => {
 		});
 
 		// gql input
-		const query = `
-			query getQuestions($EventId: ID!) {
-				questions(EventId: $EventId) {
-					id
-					EventId
-					GuestId
-					createdAt
-					content
-					state
-					isStared
-					likeCount
-					QuestionId
-				}
-			}
+		const query = gql`
+            query getQuestions($EventId: ID!) {
+                questions(EventId: $EventId) {
+                    id
+                    EventId
+                    GuestId
+                    createdAt
+                    content
+                    state
+                    isStared
+                    likeCount
+                    QuestionId
+                }
+            }
 		`;
 		const variables = {
 			EventId,
@@ -106,20 +107,20 @@ describe("graphql yoga question model", () => {
 	});
 
 	it("should be able to pass schema test 'query questions'", async () => {
-		const query = `
-			query getQuestions($EventId: ID!) {
-				questions(EventId: $EventId) {
-					id
-					EventId
-					GuestId
-					createdAt
-					content
-					state
-					isStared
-					likeCount
-					QuestionId
-				}
-			}
+		const query = gql`
+            query getQuestions($EventId: ID!) {
+                questions(EventId: $EventId) {
+                    id
+                    EventId
+                    GuestId
+                    createdAt
+                    content
+                    state
+                    isStared
+                    likeCount
+                    QuestionId
+                }
+            }
 		`;
 
 		const variables = {


### PR DESCRIPTION
# Add graphql test
* add: test of graphql `createEvent` mutation
* add: test of graphql `updateEvent` query

* chore: apply graphql-tag at graphql string for IDE assist in graphql 

# Fix bug
fix: updateEventResolver에서 updatedEvent 객체의 get function이 없다는 에러 발생
에러: updatedEvent 객체의 get function이 없다는 에러 발생
원인: simple object 로 변환된 값을 또 한번 변환하려고 함
해결: simple object 로 변환하지않고 바로 반환하도록 수정

# Add some todo comment
* chore: add todo: resolver의 return 값 및 해당 scheme의 return type refactor
* chore: add todo: rename to findOrCreateEvent