### PR TITLE
Resolver todo and refactoring

### DIFF
--- a/backend/DB/queries/event.js
+++ b/backend/DB/queries/event.js
@@ -21,8 +21,7 @@ export async function getAllEvents() {
  * @param endAt {Date}
  * @returns {Promise<object>}
  */
-// todo: rename to findOrCreateEvent
-export async function createEvent({
+export async function findOrCreateEvent({
 	eventName,
 	eventCode,
 	HostId,

--- a/backend/constants/socket.io-Events.js
+++ b/backend/constants/socket.io-Events.js
@@ -1,0 +1,7 @@
+export const SOCKET_IO_EVENT_JOIN_ROOM = "joinRoom";
+export const SOCKET_IO_EVENT_LEAVE_ROOM = "leaveRoom";
+export const SOCKET_IO_EVENT_ERROR = "error";
+export const SOCKET_IO_EVENT_CONNECTION = "connection";
+export const SOCKET_IO_EVENT_DISCONNECTING = "disconnecting";
+export const SOCKET_IO_EVENT_DISCONNECT = "disconnect";
+

--- a/backend/graphQL/model/hostpage/hostpage.resolver.js
+++ b/backend/graphQL/model/hostpage/hostpage.resolver.js
@@ -1,6 +1,6 @@
 import faker from "faker";
 import {
-	createEvent,
+	findOrCreateEvent,
 	getAllEvents,
 	getEventById,
 	getEventOptionByEventId,
@@ -85,7 +85,7 @@ const createHashTagsResolver = async (_, {hashTags}, authority) => {
 const createEventResolver = async (_, {info}, authority) => {
 	verifySubjectHostJwt(authority.sub);
 	const eventCode = await generateEventCode();
-	const event = await createEvent({
+	const event = await findOrCreateEvent({
 		eventName: info.eventName,
 		eventCode,
 		HostId: authority.info.id,

--- a/backend/socket_io_server/RoomSocket.js
+++ b/backend/socket_io_server/RoomSocket.js
@@ -1,3 +1,5 @@
+import {SOCKET_IO_EVENT_JOIN_ROOM, SOCKET_IO_EVENT_LEAVE_ROOM} from "../constants/socket.io-Events.js";
+
 class RoomSocket {
 	constructor({socket, server, handlerEventPair}) {
 		this.socket = socket;
@@ -15,7 +17,7 @@ class RoomSocket {
 			this.addListener(eventName, handler),
 		);
 
-		this.socket.emit("joinRoom");
+		this.socket.emit(SOCKET_IO_EVENT_JOIN_ROOM);
 	}
 
 	leaveRoom() {
@@ -25,7 +27,7 @@ class RoomSocket {
 			this.socket.removeListener(eventName, handler),
 		);
 
-		this.socket.emit("leaveRoom");
+		this.socket.emit(SOCKET_IO_EVENT_LEAVE_ROOM);
 
 		this.room = null;
 		this.registeredHandler = [];

--- a/backend/socket_io_server/RoomSocketHelper.js
+++ b/backend/socket_io_server/RoomSocketHelper.js
@@ -1,5 +1,6 @@
 import logger from "./logger.js";
 import RoomSocket from "./RoomSocket.js";
+import {SOCKET_IO_EVENT_JOIN_ROOM, SOCKET_IO_EVENT_LEAVE_ROOM} from "../constants/socket.io-Events.js";
 
 const RoomSocketHelper = ({server, socket, handlerEventPair}) => {
 	const id = socket.id;
@@ -38,8 +39,8 @@ const RoomSocketHelper = ({server, socket, handlerEventPair}) => {
 		}
 	};
 
-	socket.on("joinRoom", onJoinRoom);
-	socket.on("leaveRoom", onLeaveRoom);
+	socket.on(SOCKET_IO_EVENT_JOIN_ROOM, onJoinRoom);
+	socket.on(SOCKET_IO_EVENT_LEAVE_ROOM, onLeaveRoom);
 };
 
 export default RoomSocketHelper;

--- a/backend/socket_io_server/app.js
+++ b/backend/socket_io_server/app.js
@@ -7,6 +7,12 @@ import logger from "./logger.js";
 import authenticate from "./middleware/authenticate";
 import RoomSocketHelper from "./RoomSocketHelper.js";
 import socketHandlers from "./socketHandler";
+import {
+	SOCKET_IO_EVENT_CONNECTION,
+	SOCKET_IO_EVENT_DISCONNECT,
+	SOCKET_IO_EVENT_DISCONNECTING,
+	SOCKET_IO_EVENT_ERROR,
+} from "../constants/socket.io-Events.js";
 
 dotenv.config();
 
@@ -22,7 +28,7 @@ const socketServer = io(httpServer);
 const namedServer = socketServer.of(NAME_SPACE);
 
 socketServer.use(authenticate());
-namedServer.on("connection", async socket => {
+namedServer.on(SOCKET_IO_EVENT_CONNECTION, async socket => {
 	const id = socket.id;
 
 	logger.info(`id ${id} connected at /${NAME_SPACE}`);
@@ -33,13 +39,13 @@ namedServer.on("connection", async socket => {
 		handlerEventPair: socketHandlers,
 	});
 
-	socket.on("error", error =>
+	socket.on(SOCKET_IO_EVENT_ERROR, error =>
 		logger.info(`error occur at socket id ${id} disconnected ${error}`),
 	);
-	socket.on("disconnecting", reason => {
+	socket.on(SOCKET_IO_EVENT_DISCONNECTING, reason => {
 		logger.info(`disconnecting at id ${id}, reason:${reason}`);
 	});
-	socket.on("disconnect", reason => {
+	socket.on(SOCKET_IO_EVENT_DISCONNECT, reason => {
 		logger.info(`socket id ${id} disconnected reason:${reason}`);
 	});
 });

--- a/backend/socket_io_server/socketHandler/Hello.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Hello.socketHandler.js
@@ -8,7 +8,7 @@ function verySlowJob() {
 	);
 }
 
-const helloHandler = async (data, emit) => {
+const helloSocketHandler = async (data, emit) => {
 	try {
 		// console.log(data);
 
@@ -26,5 +26,5 @@ const eventName = "hello";
 
 export default {
 	eventName,
-	handler: helloHandler,
+	handler: helloSocketHandler,
 };

--- a/backend/socket_io_server/socketHandler/Question/removeQuestion.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/removeQuestion.socketHandler.js
@@ -1,6 +1,6 @@
 import {deleteQuestionById} from "../../../DB/queries/question";
 
-const questionCreateSocketHandler = async (data, emit) => {
+const createQuestionSocketHandler = async (data, emit) => {
 	await deleteQuestionById(data.id);
 
 	emit(data);
@@ -10,5 +10,5 @@ const eventName = "question/remove";
 
 export default {
 	eventName,
-	handler: questionCreateSocketHandler,
+	handler: createQuestionSocketHandler,
 };

--- a/backend/socket_io_server/socketHandler/emoji/addEmoji.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/emoji/addEmoji.socketHandler.js
@@ -1,6 +1,6 @@
 import {createEmoji} from "../../../DB/queries/emoji.js";
 
-const moveQuestionSocketHandler = async (data, emit) => {
+const addEmojiSocketHandler = async (data, emit) => {
 	const {GuestId, name, EventId, QuestionId} = data;
 	const res = await createEmoji({GuestId, name, EventId, QuestionId});
 
@@ -11,5 +11,5 @@ const eventName = "questionEmoji/create";
 
 export default {
 	eventName,
-	handler: moveQuestionSocketHandler,
+	handler: addEmojiSocketHandler,
 };

--- a/backend/spec/DB/queries/eventQuery.test.js
+++ b/backend/spec/DB/queries/eventQuery.test.js
@@ -1,7 +1,7 @@
 import assert from "assert";
 import {before, describe, it} from "mocha";
 import {
-	createEvent,
+	findOrCreateEvent,
 	getAllEvents,
 	getEventByEventCode,
 	getEventById,
@@ -21,7 +21,7 @@ describe("event query api", () => {
 		const eventName = "event name";
 		const HostId = null;
 
-		await createEvent({eventCode, HostId, eventName});
+		await findOrCreateEvent({eventCode, HostId, eventName});
 
 		const res = await getAllEvents();
 
@@ -34,7 +34,7 @@ describe("event query api", () => {
 		const eventName = "event name";
 		const HostId = null;
 
-		const res = await createEvent({eventCode, HostId, eventName});
+		const res = await findOrCreateEvent({eventCode, HostId, eventName});
 
 		assert(typeof res === "object");
 		assert(res.id > 0);
@@ -59,7 +59,7 @@ describe("event query api", () => {
 			startAt: new Date(),
 			endAt: new Date(),
 		};
-		const oldEvent = await createEvent(oldData);
+		const oldEvent = await findOrCreateEvent(oldData);
 		const id = oldEvent.id;
 
 		const event = await getEventById(id);
@@ -107,7 +107,7 @@ describe("event query api", () => {
 			startAt: new Date(),
 			endAt: new Date(),
 		};
-		const oldEvent = await createEvent(oldData);
+		const oldEvent = await findOrCreateEvent(oldData);
 		const id = oldEvent.id;
 
 		const event = await getEventByEventCode(oldData.eventCode);
@@ -142,7 +142,7 @@ describe("event query api", () => {
 			endAt: new Date(),
 		};
 
-		await createEvent(oldData);
+		await findOrCreateEvent(oldData);
 
 		const events = await getEventsByHostId(oldData.HostId);
 
@@ -159,7 +159,7 @@ describe("event query api", () => {
 			startAt: new Date(),
 			endAt: new Date(),
 		};
-		const oldEvent = await createEvent(oldData);
+		const oldEvent = await findOrCreateEvent(oldData);
 		const id = oldEvent.id;
 
 		const event = await getEventOptionByEventId(id);
@@ -179,7 +179,7 @@ describe("event query api", () => {
 			endAt: new Date(),
 		};
 
-		await createEvent(oldData);
+		await findOrCreateEvent(oldData);
 		const id = 7777;
 
 		const event = await getEventOptionByEventId(id);

--- a/backend/spec/DB/queries/hashtagQuery.test.js
+++ b/backend/spec/DB/queries/hashtagQuery.test.js
@@ -8,7 +8,7 @@ import {
 	updateHashtagById,
 } from "../../../DB/queries/hashtag.js";
 import models from "../../../DB/models";
-import {createEvent} from "../../../DB/queries/event.js";
+import {findOrCreateEvent} from "../../../DB/queries/event.js";
 
 describe("hashtag query api", () => {
 	before(async () => {
@@ -80,7 +80,7 @@ describe("hashtag query api", () => {
 			startAt: new Date(),
 			endAt: new Date(),
 		};
-		const oldEvent = await createEvent(oldData);
+		const oldEvent = await findOrCreateEvent(oldData);
 		const EventId = oldEvent.id;
 		const name = "name";
 

--- a/backend/spec/graphql/emoji.test.js
+++ b/backend/spec/graphql/emoji.test.js
@@ -8,7 +8,7 @@ import resolvers from "../../graphQL/resolvers.js";
 import SequelizeTestHelper from "../testHelper/SequelizeTestHelper.js";
 import {createEmoji} from "../../DB/queries/emoji.js";
 import models from "../../DB/models";
-import {createEvent} from "../../DB/queries/event.js";
+import {findOrCreateEvent} from "../../DB/queries/event.js";
 import {createQuestion} from "../../DB/queries/question.js";
 import {createGuest} from "../../DB/queries/guest.js";
 
@@ -39,7 +39,7 @@ describe("graphql yoga emoji model", () => {
 		const eventName = "event name";
 		const eventCode = "event code";
 		const HostId = null;
-		const event = await createEvent({eventName, eventCode, HostId});
+		const event = await findOrCreateEvent({eventName, eventCode, HostId});
 		const EventId = event.id;
 
 		const content = "content";
@@ -138,7 +138,7 @@ describe("graphql yoga emoji model", () => {
 		const eventName = "event name";
 		const eventCode = "event code";
 		const HostId = null;
-		const event = await createEvent({eventName, eventCode, HostId});
+		const event = await findOrCreateEvent({eventName, eventCode, HostId});
 		const EventId = event.id;
 
 		const guest = await createGuest(EventId);

--- a/backend/spec/graphql/guest.test.js
+++ b/backend/spec/graphql/guest.test.js
@@ -8,7 +8,7 @@ import typeDefs from "../../graphQL/typeDefs.js";
 import resolvers from "../../graphQL/resolvers.js";
 import models from "../../DB/models";
 import {createGuest} from "../../DB/queries/guest.js";
-import {createEvent} from "../../DB/queries/event.js";
+import {findOrCreateEvent} from "../../DB/queries/event.js";
 import {AUTHORITY_TYPE_GUEST} from "../../constants/authorityTypes.js";
 import {findOrCreateHostByOAuth} from "../../DB/queries/host.js";
 
@@ -46,7 +46,7 @@ describe("graphql yoga guest model", () => {
 		const HostId = null;
 		const eventName = "eventName";
 		const eventCode = "eventCord";
-		const event = await createEvent({eventCode, eventName, HostId});
+		const event = await findOrCreateEvent({eventCode, eventName, HostId});
 
 		const EventId = event.id;
 		const guest = await createGuest(EventId);
@@ -120,7 +120,7 @@ describe("graphql yoga guest model", () => {
 		const HostId = null;
 		const eventName = "eventName";
 		const eventCode = "eventCord";
-		const event = await createEvent({eventCode, eventName, HostId});
+		const event = await findOrCreateEvent({eventCode, eventName, HostId});
 
 		const EventId = event.id;
 		const guest = await createGuest(EventId);
@@ -150,7 +150,7 @@ describe("graphql yoga guest model", () => {
 		const HostId = host.id;
 		const eventName = "eventName";
 		const eventCode = "eventCord";
-		const event = await createEvent({eventCode, eventName, HostId});
+		const event = await findOrCreateEvent({eventCode, eventName, HostId});
 
 		const EventId = event.id;
 		const guest = await createGuest(EventId);
@@ -259,7 +259,7 @@ describe("graphql yoga guest model", () => {
 		const HostId = host.id;
 		const eventName = "eventName";
 		const eventCode = "eventCord";
-		const event = await createEvent({eventCode, eventName, HostId});
+		const event = await findOrCreateEvent({eventCode, eventName, HostId});
 
 		const EventId = event.id;
 		const guest = await createGuest(EventId);

--- a/backend/spec/graphql/hostpage.test.js
+++ b/backend/spec/graphql/hostpage.test.js
@@ -8,7 +8,7 @@ import SequelizeTestHelper from "../testHelper/SequelizeTestHelper.js";
 import models from "../../DB/models";
 import hostpageResolvers from "../../graphQL/model/hostpage/hostpage.resolver.js";
 import {AUTHORITY_TYPE_HOST} from "../../constants/authorityTypes.js";
-import {createEvent} from "../../DB/queries/event.js";
+import {findOrCreateEvent} from "../../DB/queries/event.js";
 import {findOrCreateHostByOAuth} from "../../DB/queries/host.js";
 import {createHashtag} from "../../DB/queries/hashtag.js";
 
@@ -64,12 +64,12 @@ describe("graphql yoga hostpage model", () => {
 		});
 
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
 		});
-		const event2 = await createEvent({
+		const event2 = await findOrCreateEvent({
 			eventCode: "eventCode2",
 			eventName: "eventname2",
 			HostId,
@@ -237,12 +237,12 @@ describe("graphql yoga hostpage model", () => {
 		});
 
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
 		});
-		const event2 = await createEvent({
+		const event2 = await findOrCreateEvent({
 			eventCode: "eventCode2",
 			eventName: "eventname2",
 			HostId,
@@ -278,7 +278,7 @@ describe("graphql yoga hostpage model", () => {
 			name: "host name",
 		});
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
@@ -344,7 +344,7 @@ describe("graphql yoga hostpage model", () => {
 			name: "host name",
 		});
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
@@ -373,7 +373,7 @@ describe("graphql yoga hostpage model", () => {
 			name: "host name",
 		});
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
@@ -446,7 +446,7 @@ describe("graphql yoga hostpage model", () => {
 			name: "host name",
 		});
 		const HostId = host.id;
-		const event1 = await createEvent({
+		const event1 = await findOrCreateEvent({
 			eventCode: "eventCode1",
 			eventName: "eventname1",
 			HostId,
@@ -477,7 +477,7 @@ describe("graphql yoga hostpage model", () => {
 		assert.equal(resultHashtag.EventId, EventId);
 	});
 
-	it("should be able to mutate 'createEvent'", async () => {
+	it("should be able to mutate 'findOrCreateEvent'", async () => {
 		// given
 		const host = await findOrCreateHostByOAuth({
 			oauthId: "oauthId",
@@ -542,7 +542,7 @@ describe("graphql yoga hostpage model", () => {
 		assert.equal(new Date(parseInt(result.endAt, 10)).toISOString(), endAt);
 	});
 
-	it("should be able to pass schema test 'mutate createEvent'", async () => {
+	it("should be able to pass schema test 'mutate findOrCreateEvent'", async () => {
 		const query = gql`
 			mutation Query($info: EventInfo!) {
 				createEvent(info: $info) {
@@ -570,7 +570,7 @@ describe("graphql yoga hostpage model", () => {
 		await gqlTester.test(true, query, variables);
 	});
 
-	it("should be able to resolve 'createEvent' by resolver", async () => {
+	it("should be able to resolve 'findOrCreateEvent' by resolver", async () => {
 		// given
 		const host = await findOrCreateHostByOAuth({
 			oauthId: "oauthId",
@@ -620,7 +620,7 @@ describe("graphql yoga hostpage model", () => {
 		const eventName = "eventName";
 		const eventCode = "eventCode";
 
-		const event = await createEvent({eventName, eventCode, HostId});
+		const event = await findOrCreateEvent({eventName, eventCode, HostId});
 		const EventId = event.id;
 
 		const startAt = new Date().toISOString();
@@ -717,7 +717,7 @@ describe("graphql yoga hostpage model", () => {
 		const eventName = "eventName";
 		const eventCode = "eventCode";
 
-		const event = await createEvent({eventName, eventCode, HostId});
+		const event = await findOrCreateEvent({eventName, eventCode, HostId});
 		const EventId = event.id;
 
 		const startAt = new Date().toISOString();

--- a/backend/spec/graphql/question.test.js
+++ b/backend/spec/graphql/question.test.js
@@ -9,7 +9,7 @@ import models from "../../DB/models";
 import {createGuest} from "../../DB/queries/guest.js";
 import {createQuestion} from "../../DB/queries/question.js";
 import questionResolvers from "../../graphQL/model/question/question.resolver.js";
-import {createEvent} from "../../DB/queries/event.js";
+import {findOrCreateEvent} from "../../DB/queries/event.js";
 
 describe("graphql yoga question model", () => {
 	const sequelizeMock = new SequelizeTestHelper();
@@ -43,7 +43,7 @@ describe("graphql yoga question model", () => {
 
 	it("should be able to query 'questions'", async () => {
 		// given
-		const event = await createEvent({
+		const event = await findOrCreateEvent({
 			eventName: "event name",
 			eventCode: "event code",
 			HostId: null,


### PR DESCRIPTION
# Refactoring: change function name createEvent -> findOrCreateEvent

* why: 내부에 find or create 하는 동작을 함수명에서 유추 할 수 없음.
* what: event DB query api 의 createEvent의 이름 변경
* etc: resolve todo: rename to findOrCreateEvent

# Refactoring: change socket handler name

* why: socket handler의 이름 일관성 유지

change function name: moveQuestionSocketHandler -> addEmojiSocketHandler
change function name: questionCreateSocketHandler -> createQuestionSocketHandler
change function name: helloHandler -> helloSocketHandler

# Refactoring: extract string constant of socket.io event name 

* why: clean code '문자열 상수 추출'
* socket.io에서 사용되는 event name 에 해당하는 문자열 상수를 socket.io-Events.js 모아놓음