### PR TITLE
fix: test App component of guest-app

### DIFF
--- a/frontend/guest-app/src/components/atoms/TopProcessBar.js
+++ b/frontend/guest-app/src/components/atoms/TopProcessBar.js
@@ -9,6 +9,14 @@ TopBarProgress.config({
 	shadowBlur: 5,
 });
 
+const topbar = {
+	show() {
+
+	},
+	hide() {
+	},
+};
+
 export default function TopProgressBar() {
-	return <TopBarProgress />;
+	return <TopBarProgress topbar={topbar}/>;
 }


### PR DESCRIPTION
1. App 컴포넌트 테스트시  TopProgressBar에서 null에 대해 shadowBlur property 접근 에러 발생
2. TopProgressBar내부의 `react-topbar-progress-indicator` 모듈에서 발생하는문제
3. `react-topbar-progress-indicator` 패키지 뜯어보니, 테스트상에서 topbar props 사용하는것을 확인
4. wrapping된 컴포넌트인 TopProgressBar에 topbar props를 추가로 해결함