### PR TITLE
fix: branch safe list allow all branch of travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: node_js
 node_js:
   - 10
 
-#branches:
-#  only:
-#    - master
-#    - Develope
+branches:
+  only:
+    - /.*/
 
 cache:
   yarn: true
@@ -14,8 +13,6 @@ cache:
 #    - ./frontend/host-app/node_modules
 #    - ./frontend/guest-app/node_modules
 #    - ./frontend/main-app/node_modules
-
-
 
 install:
   - yarn install


### PR DESCRIPTION
원인: 빌드 트리거는 작동하나, github 에서 travis status icon 이 나오지 않음
해결: branch safe list를 모든 branch를 build 하도록 명시적으로 수정함

