### PR TITLE
refactoring: 기존에 합쳐진 개별 질문을 이동하는 기능과 전체 질문 이동의 기능을 분리

### DIFF
--- a/backend/DB/queries/question.js
+++ b/backend/DB/queries/question.js
@@ -152,13 +152,7 @@ export async function getQuestionById(id) {
 	return res;
 }
 
-// todo what ???
 // todo implement test code
-export async function updateEveryState(from, {state}) {
-	return Question.update(
-		{
-			state,
-		},
-		{where: {state: from}},
-	);
+export async function updateQuestionsByStateAndEventId({from, to, EventId}) {
+	return Question.update({state: to}, {where: {state: from, EventId}});
 }

--- a/backend/socket_io_server/socketHandler/Question/moveQuestion.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/moveQuestion.socketHandler.js
@@ -1,21 +1,12 @@
-import {
-	updateEveryState,
-	updateQuestionById,
-} from "../../../DB/queries/question";
+import {updateQuestionById} from "../../../DB/queries/question";
 import logger from "../../logger.js";
 import {SOCKET_IO_RESPONSE_STATE_ERROR} from "../../../constants/socket.ioResponseState.js";
-import {QUESTION_STATE_ACTIVE} from "../../../constants/questionState.js";
 
 const moveQuestionSocketHandler = async (data, emit) => {
 	try {
-		const id = data.id;
-		const state = data.to;
+		const {id, to} = data;
 
-		if (id === "all") {
-			await updateEveryState(QUESTION_STATE_ACTIVE, {state});
-		} else {
-			await updateQuestionById({id, state});
-		}
+		await updateQuestionById({id, state: to});
 
 		emit(data);
 	} catch (e) {

--- a/backend/socket_io_server/socketHandler/Question/moveQuestions.socketHandler.js
+++ b/backend/socket_io_server/socketHandler/Question/moveQuestions.socketHandler.js
@@ -1,0 +1,22 @@
+import {updateQuestionsByStateAndEventId} from "../../../DB/queries/question.js";
+import logger from "../../logger.js";
+import {SOCKET_IO_RESPONSE_STATE_ERROR} from "../../../constants/socket.ioResponseState.js";
+
+const moveQuestionsSocketHandler = async (data, emit) => {
+	try {
+		const {to, from, EventId} = data;
+
+		await updateQuestionsByStateAndEventId({from, to, EventId});
+
+		emit(data);
+	} catch (e) {
+		logger.error(e);
+
+		emit({status: SOCKET_IO_RESPONSE_STATE_ERROR, e});
+	}
+};
+
+export default {
+	eventName: "questions/move",
+	handler: moveQuestionsSocketHandler,
+};

--- a/backend/socket_io_server/socketHandler/index.js
+++ b/backend/socket_io_server/socketHandler/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable array-element-newline */
 import addEmoji from "./emoji/addEmoji.socketHandler.js";
 import removeEmoji from "./emoji/removeEmoji.socketHandler.js";
 import initOption from "./Event/initOption.socketHandler.js";
@@ -19,6 +20,7 @@ import rateOff from "./Vote/rateOff.socketHandler.js";
 import voteOn from "./Vote/voteOn.socketHandler.js";
 import voteOff from "./Vote/voteOff.socketHandler.js";
 import hello from "./Hello.socketHandler.js";
+import moveQuestions from "./Question/moveQuestions.socketHandler.js";
 
 const socketHandlers = [
 	addEmoji,
@@ -42,6 +44,7 @@ const socketHandlers = [
 	voteOn,
 	voteOff,
 	hello,
+	moveQuestions,
 ];
 
 export default socketHandlers;

--- a/frontend/guest-app/src/contexts/Questions/QuestionsProvider.js
+++ b/frontend/guest-app/src/contexts/Questions/QuestionsProvider.js
@@ -95,6 +95,12 @@ const useSocketHandler = (dispatch, guestGlobal) => {
 
 		dispatch({type: QUESTION_ACTION_TYPE_TOGGLE_STAR_QUESTION, data: req});
 	});
+
+	useSocket("questions/move", req => {
+		req.guestGlobal = guestGlobal;
+
+		dispatch({type: "moveQuestions", data: req});
+	});
 };
 
 function QuestionsProvider(props) {

--- a/frontend/guest-app/src/reducers/QuestionsRepliesReducer.js
+++ b/frontend/guest-app/src/reducers/QuestionsRepliesReducer.js
@@ -38,7 +38,8 @@ const onQuestionLike = (state, data) => {
 
 const onUndoQuestionLike = (state, data) => {
 	const guestGlobal = data.guestGlobal;
-	const newState = state.map(x => {
+
+	return state.map(x => {
 		const {QuestionId, GuestId} = data;
 
 		if (x.id !== QuestionId) {
@@ -55,8 +56,6 @@ const onUndoQuestionLike = (state, data) => {
 
 		return newX;
 	});
-
-	return newState;
 };
 
 const onAddQuestionEmoji = (state, data) => {
@@ -66,7 +65,7 @@ const onAddQuestionEmoji = (state, data) => {
 
 	newState.forEach(question => {
 		if (question.id !== QuestionId) {
-			return question;
+			return;
 		}
 
 		let isFound = false;
@@ -152,22 +151,26 @@ const onUpdateQuestion = (state, data) => {
 	return newState;
 };
 
-const onMoveQuestion = (state, data) => {
+const onMoveQuestions = (state, data) => {
 	const newState = _.cloneDeep(state);
 
-	if (data.id === "all") {
-		return newState.map(e => {
-			if (e.state === data.from) {
-				e.state = data.to;
-			}
-			return e;
-		});
-	}
+	return newState.map(e => {
+		if (e.state === data.from) {
+			e.state = data.to;
+		}
+
+		return e;
+	});
+};
+
+const onMoveQuestion = (state, data) => {
+	const newState = _.cloneDeep(state);
 
 	return newState.map(e => {
 		if (e.id === data.id) {
 			e.state = data.to;
 		}
+
 		return e;
 	});
 };
@@ -203,6 +206,7 @@ const QuestionsRepliesReducer = (state, action) => {
 		removeQuestion: onRemoveQuestion,
 		updateQuestion: onUpdateQuestion,
 		moveQuestion: onMoveQuestion,
+		moveQuestions: onMoveQuestions,
 		toggleStarQuestion: onToggleStarQuestion,
 	};
 

--- a/frontend/host-app/src/components/EventDashboard/Buttons/CompleteAllQuestionButton.js
+++ b/frontend/host-app/src/components/EventDashboard/Buttons/CompleteAllQuestionButton.js
@@ -2,17 +2,27 @@ import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useButtonStyles.js";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestions} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 function CompleteAllQuestionButton({data}) {
 	const classes = useStyles();
 
+	// todo extract constant
 	return (
 		<>
 			<Tooltip title="모든 질문 완료">
 				<Icon
 					className={classes.completeAllButton}
-					onClick={() => handleQuestionDatas(data, "all", "active", "completeQuestion")}
+					onClick={() => {
+						// todo fix me
+						const EventId = data.questions[0].EventId;
+
+						handleMoveQuestions(
+							EventId,
+							"active",
+							"completeQuestion",
+						);
+					}}
 				>
 					launch
 				</Icon>
@@ -20,5 +30,5 @@ function CompleteAllQuestionButton({data}) {
 		</>
 	);
 }
-export default CompleteAllQuestionButton;
 
+export default CompleteAllQuestionButton;

--- a/frontend/host-app/src/components/EventEmiter/QuestionSocketEventEmiter.js
+++ b/frontend/host-app/src/components/EventEmiter/QuestionSocketEventEmiter.js
@@ -1,6 +1,10 @@
 import {socketClient} from "../../libs/socket.io-Client-wrapper";
 
-const handleQuestionDatas = (questions, id, from, to) => {
+const handleMoveQuestions = (EventId, from, to) => {
+	socketClient.emit("questions/move", {from, to, EventId});
+};
+
+const handleMoveQuestion = (questions, id, from, to) => {
 	const questionData = questions.questions.find(e => e.id === id);
 
 	socketClient.emit("question/move", {id, from, to, data: questionData});
@@ -12,9 +16,11 @@ const handleStar = (questions, id) => {
 			if (e.isStared) {
 				acc.from.push({id: e.id, isStared: !e.isStared});
 			}
+
 			if (e.id === id) {
 				acc.to.push({id: e.id, isStared: !e.isStared});
 			}
+
 			return acc;
 		},
 		{from: [], to: []},
@@ -23,4 +29,4 @@ const handleStar = (questions, id) => {
 	socketClient.emit("question/toggleStar", toggleMsg);
 };
 
-export {handleQuestionDatas, handleStar};
+export {handleMoveQuestion, handleStar, handleMoveQuestions};

--- a/frontend/host-app/src/components/EventHandler/useQuestionSocketEventHandler.js
+++ b/frontend/host-app/src/components/EventHandler/useQuestionSocketEventHandler.js
@@ -14,6 +14,10 @@ const useQuestionSocketEventHandler = dispatch => {
 		dispatch({type: "moveQuestion", data: req}),
 	);
 
+	useSocket("questions/move", req =>
+		dispatch({type: "moveQuestions", data: req}),
+	);
+
 	useSocket("question/remove", req =>
 		dispatch({type: "removeQuestion", data: req}),
 	);

--- a/frontend/host-app/src/components/Questions/Buttons/ApproveButton.js
+++ b/frontend/host-app/src/components/Questions/Buttons/ApproveButton.js
@@ -2,7 +2,7 @@ import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useButtonStyles.js";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestion} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 function ApproveButton(props) {
 	const classes = useStyles();
@@ -12,7 +12,7 @@ function ApproveButton(props) {
 			<Tooltip title="승인">
 				<Icon
 					className={classes.approveButton}
-					onClick={() => handleQuestionDatas(props.data, props.id, props.type, "active")}>
+					onClick={() => handleMoveQuestion(props.data, props.id, props.type, "active")}>
 					check_circle_outline
 				</Icon>
 			</Tooltip>

--- a/frontend/host-app/src/components/Questions/Buttons/QuestionCompleteButton.js
+++ b/frontend/host-app/src/components/Questions/Buttons/QuestionCompleteButton.js
@@ -2,7 +2,7 @@ import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useButtonStyles.js";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestion} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 function QuestionCompleteButton(props) {
 	const classes = useStyles();
@@ -12,7 +12,7 @@ function QuestionCompleteButton(props) {
 			<Tooltip title="답변 완료">
 				<Icon
 					className={classes.approveButton}
-					onClick={() => handleQuestionDatas(props.data, props.id, props.type, "completeQuestion")}>
+					onClick={() => handleMoveQuestion(props.data, props.id, props.type, "completeQuestion")}>
 					check_circle_outline
 				</Icon>
 			</Tooltip>

--- a/frontend/host-app/src/components/Questions/Buttons/QuestionMenuButton.js
+++ b/frontend/host-app/src/components/Questions/Buttons/QuestionMenuButton.js
@@ -4,7 +4,7 @@ import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import {Icon} from "@material-ui/core";
 import useStyle from "./useButtonStyles";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestion} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 const ITEM_HEIGHT = 48;
 
@@ -22,7 +22,7 @@ export default function QuestionMenuButton(props) {
 	};
 
 	const handleDelete = () => {
-		handleQuestionDatas(props.data, props.id, props.type, "deleted");
+		handleMoveQuestion(props.data, props.id, props.type, "deleted");
 		handleClose();
 	};
 

--- a/frontend/host-app/src/components/Questions/Buttons/QuestionRestoreButton.js
+++ b/frontend/host-app/src/components/Questions/Buttons/QuestionRestoreButton.js
@@ -2,7 +2,7 @@ import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useButtonStyles.js";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestion} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 function QuestionRestoreButton(props) {
 	const classes = useStyles();
@@ -12,7 +12,7 @@ function QuestionRestoreButton(props) {
 			<Tooltip title="질문 되살리기">
 				<Icon
 					className={classes.restoreButton}
-					onClick={() => handleQuestionDatas(props.data, props.id, props.type, "active")}>
+					onClick={() => handleMoveQuestion(props.data, props.id, props.type, "active")}>
 					restore
 				</Icon>
 			</Tooltip>

--- a/frontend/host-app/src/components/Questions/Buttons/RejectButton.js
+++ b/frontend/host-app/src/components/Questions/Buttons/RejectButton.js
@@ -2,7 +2,7 @@ import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import {Icon} from "@material-ui/core";
 import useStyles from "./useButtonStyles.js";
-import {handleQuestionDatas} from "../../EventEmiter/QuestionSocketEventEmiter.js";
+import {handleMoveQuestion} from "../../EventEmiter/QuestionSocketEventEmiter.js";
 
 function RejectButton(props) {
 	const classes = useStyles();
@@ -12,7 +12,7 @@ function RejectButton(props) {
 			<Tooltip title="거절">
 				<Icon
 					className={classes.cancelButton}
-					onClick={() => handleQuestionDatas(props.data, props.id, props.type, "delete")}>
+					onClick={() => handleMoveQuestion(props.data, props.id, props.type, "delete")}>
 					highlight_off
 				</Icon>
 			</Tooltip>

--- a/frontend/host-app/src/components/Questions/QuestionReducer.js
+++ b/frontend/host-app/src/components/Questions/QuestionReducer.js
@@ -11,32 +11,34 @@ const QuestionsReducer = (state, action) => {
 
 			return {questions: [...newData]};
 		},
+		moveQuestions: () => {
+			const newData = state.questions.map(e => {
+				if (e.state === action.data.from) {
+					e.state = action.data.to;
+				}
+
+				return e;
+			});
+
+			return {questions: [...newData]};
+		},
 		moveQuestion: () => {
-			let newData;
+			const newData = state.questions.map(e => {
+				if (e.id === action.data.id) {
+					e.state = action.data.to;
+				}
 
-			if (action.data.id === "all") {
-				newData = state.questions.map(e => {
-					if (e.state === action.data.from) {
-						e.state = action.data.to;
-					}
-
-					return e;
-				});
-			} else {
-				newData = state.questions.map(e => {
-					if (e.id === action.data.id) {
-						e.state = action.data.to;
-					}
-
-					return e;
-				});
-			}
+				return e;
+			});
 
 			return {questions: [...newData]};
 		},
 		updateQuestion: () => {
 			const newData = state.questions.map(e => {
-				if (e.id === action.data.id) { e.content = action.data.content; }
+				if (e.id === action.data.id) {
+					e.content = action.data.content;
+				}
+
 				return e;
 			});
 


### PR DESCRIPTION
# Feature refactoring 
기존에 합쳐진 개별 질문을 이동하는 기능과 전체 질문 이동의 기능을 분리

## backend - socket.io

* moveQuestion 핸들러에서 moveQuestions 분리 및 등록

## backend - db query api

* 기존 모호한 함수명 변경
   -> `updateEveryState` -> updateQuestionsByStateAndEventId`
* 하나의 event의 질문만 상태 변경하기위해 EventId를 인자로 추가

## frontend - host, guest app

* 기존 모호한 이름의 `handleQuestionDatas`를  `handleMoveQuestion`, `handleMoveQuestions` 로 변경
* 전체 질문 이동기능을 moveQuestions 함수로 분리
* react reducer 에 `moveQuestions` action  추가 구현
* useSocket에 `questions/move` 이벤트 추가
* add todo